### PR TITLE
Configurable pin numbering scheme

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -5,6 +5,8 @@
 	<Template>raspibrew_bootstrap.html</Template>
 	<!-- Use LCD - yes or no-->
 	<Use_LCD>yes</Use_LCD>
+	<!-- GPIO pin numbering scheme - choose BOARD or BCM. If something else than these are given, BCM is chosen as default. -->
+	<GPIO_pin_numbering_scheme>BCM</GPIO_pin_numbering_scheme>
 	<!-- Temperature Sensor Id -->
 	<!-- For Temp Control the Temp_Sensor_Id must have a corresponding GPIO Pin used -->
 	<!-- for heat, otherwise the temperature sensor is only for temp readout -->

--- a/raspibrew.py
+++ b/raspibrew.py
@@ -235,7 +235,6 @@ def heatProcGPIO(cycle_time, duty_cycle, pinNum, conn):
     p = current_process()
     print 'Starting:', p.name, p.pid
     if pinNum > 0:
-        GPIO.setmode(GPIO.BCM)
         GPIO.setup(pinNum, GPIO.OUT)
         while (True):
             while (conn.poll()): #get last
@@ -495,6 +494,12 @@ if __name__ == '__main__':
     else:
         LCD = False 
     
+    gpioNumberingScheme = xml_root.find('GPIO_pin_numbering_scheme').text.strip()
+    if gpioNumberingScheme == "BOARD":
+        GPIO.setmode(GPIO.BOARD)
+    else:
+        GPIO.setmode(GPIO.BCM)
+
     pinHeatList=[]
     for pin in xml_root.iter('Heat_Pin'):
         pinHeatList.append(int(pin.text.strip()))
@@ -504,7 +509,6 @@ if __name__ == '__main__':
         pinGPIOList.append(int(pin.text.strip()))
         
     for pinNum in pinGPIOList:
-        GPIO.setmode(GPIO.BCM)
         GPIO.setup(pinNum, GPIO.OUT)
     
     myTempSensorNum = 0


### PR DESCRIPTION
Possibility of configuring the desired Raspberry Pi GPIO pin numbering
scheme added to config.xml with necessary changes added in
raspibrew.py. Supports either BCM or BOARD, with BCM as default
behavior.
